### PR TITLE
add `TddBrainfuckInstructionSet`

### DIFF
--- a/src/test/java/de/fxnn/brainfuck/interpreter/TddBrainfuckInstructionSet.java
+++ b/src/test/java/de/fxnn/brainfuck/interpreter/TddBrainfuckInstructionSet.java
@@ -1,0 +1,43 @@
+package de.fxnn.brainfuck.interpreter;
+
+import de.fxnn.brainfuck.program.InstructionPointer;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+
+class TddBrainfuckInstructionSet {
+
+  private final PrintWriter output;
+  private boolean label = false;
+  private boolean beginOfTest = false;
+
+  public TddBrainfuckInstructionSet(PrintWriter output) {
+    this.output = output;
+  }
+
+  public InstructionPointer step(InstructionPointer instructionPointer)
+      throws InterpreterException {
+    return switch (instructionPointer.getInstruction()) {
+      case '#' -> {
+        label = true;
+        yield instructionPointer.forward();
+      }
+      case '{' -> {
+        if (label) {
+          beginOfTest = true;
+          yield instructionPointer.forward();
+        }
+        throw new InterpreterException("'{' without preceding '#' instruction");
+      }
+      case '}' -> {
+        if (beginOfTest) {
+          beginOfTest = false;
+          output.println("PASSED");
+          yield instructionPointer.forward();
+        }
+        throw new InterpreterException("'}' without preceding '{' instruction");
+      }
+      default -> instructionPointer.forward();
+    };
+  }
+}

--- a/src/test/java/de/fxnn/brainfuck/interpreter/TddBrainfuckInstructionSetTest.java
+++ b/src/test/java/de/fxnn/brainfuck/interpreter/TddBrainfuckInstructionSetTest.java
@@ -1,0 +1,63 @@
+package de.fxnn.brainfuck.interpreter;
+
+import de.fxnn.brainfuck.program.InstructionPointer;
+import de.fxnn.brainfuck.program.StringInstructionPointer;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TddBrainfuckInstructionSetTest {
+
+  @Test
+  public void step__unknownInstruction__forward() throws InterpreterException {
+    var underTest = new TddBrainfuckInstructionSet(
+        new PrintWriter(new StringWriter()));
+    var result = underTest.step(
+        new StringInstructionPointer("x", 0));
+    Assert.assertTrue(result.isEndOfProgram());
+  }
+
+  @Test
+  public void step__beginOfTestWithoutLabel__throws() {
+    try {
+      var instructionPointer = new StringInstructionPointer("{", 0);
+      new TddBrainfuckInstructionSet(new PrintWriter(new StringWriter())).step(instructionPointer);
+      Assert.fail();
+    } catch (InterpreterException ex) {
+      Assert.assertEquals("'{' without preceding '#' instruction",
+          ex.getMessage());
+    }
+  }
+
+  @Test
+  public void step__endOfTestWithoutBeginOfTest__throws() {
+    try {
+      var instructionPointer = new StringInstructionPointer("}", 0);
+      new TddBrainfuckInstructionSet(new PrintWriter(new StringWriter())).step(instructionPointer);
+      Assert.fail();
+    } catch (InterpreterException ex) {
+      Assert.assertEquals("'}' without preceding '{' instruction",
+          ex.getMessage());
+    }
+  }
+
+  @Test
+  public void step__labelBeginEnd__passes() throws InterpreterException {
+    var output = new StringWriter();
+    var underTest = new TddBrainfuckInstructionSet(new PrintWriter(output));
+    underTest.step(
+        underTest.step(underTest.step(new StringInstructionPointer("#{}", 0))));
+    Assert.assertEquals("PASSED\n", output.toString());
+  }
+
+  @Test
+  public void step__labelBeginEnd__forward() throws InterpreterException {
+    var output = new StringWriter();
+    var underTest = new TddBrainfuckInstructionSet(new PrintWriter(output));
+    var result = underTest.step(
+        underTest.step(underTest.step(new StringInstructionPointer("#{}", 0))));
+    Assert.assertTrue(result.isEndOfProgram());
+  }
+
+}


### PR DESCRIPTION
This allows to write Brainfuck using TDD! 🤓 

Idea:

1. Divide your Brainfuck code into blocks using the `#` instruction.
2. Test all the code since the last `#` instruction by adding one or more blocks enclosed in `{`...`}`.
3. Inside the test block, place the given tape contents using space separated integers, optionally followed by an ampersand `&` and the given input characters in the same format, followed by a tilde `~`, followed by the expected tape contents after running the code, finally optionally followed by an ampersand `&` and the expected output characters.